### PR TITLE
fix qKumIW bug

### DIFF
--- a/R/dKumIW.R
+++ b/R/dKumIW.R
@@ -93,8 +93,10 @@ qKumIW <- function(p, mu, sigma, nu, lower.tail=TRUE, log.p=FALSE){
   else p <- 1 - p
   if (any(p < 0) | any(p > 1)) 
     stop(paste("p must be between 0 and 1", "\n", ""))
-  
-  q <- (-sigma / (log(1 - (1 - p)^(1/nu))))
+
+  ## FIXME: might be able to improve precision/stability via
+  ## logspace computation, e.g. see ?statnet.common::logspace.utils
+  q <- (-sigma / (log(1 - (1 - p)^(1/nu))))^(1/mu)
   q
 }
 #' @importFrom stats runif


### PR DESCRIPTION
The `qKumIW()` function appears to be a missing a `^(1/mu)` .  This also affects `rKumIW()`.  This is equivalent to fixing the value of `mu` to regardless of the actual parameter value passed by the user.

The current CRAN version should pass the first test below (where `mu=1`) and fail the second.
```r
library(RelDists)
params0 <- list(mu = 1, sigma = 2.3, nu = 3.5)
params <- list(mu = 2, sigma = 2.3, nu = 3.5)
pvec <- seq(0.01, 0.99, length = 9)
qvec <- 1:10
## round trips
rt0 <- do.call(qKumIW,
        c(list(p = do.call(pKumIW, c(list(q = qvec), params0))),
          params0)) 
stopifnot(all.equal(qvec, rt0))
rt1 <- do.call(qKumIW,
        c(list(p = do.call(pKumIW, c(list(q = qvec), params))),
          params))
stopifnot(all.equal(qvec, rt1))
```